### PR TITLE
Add Errors Codes section to the docs and some minor refactors and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ try {
   - [Functions](#functions)
     - [generateSync / generate](#generatesync--generate)
     - [verifySync / verify](#verifysync--verify)
-- [Errors](#errors)
+- [Errors Codes](#errors-codes)
 - [Supported Algorithms](#supported-algorithms)
 - [Contributing](#contributing)
 - [License](#license)
@@ -112,7 +112,7 @@ try {
 - **Flexible**: The library supports various algorithms _(symmetric & asymmetric)_ and options.
 - **Highly Configurable**: The library is highly configurable and allows you to customize the generated JWTs and the verification process.
 - **Dual Package Support**: The library supports both CommonJS and ES Modules.
-- **Well Documented**: The library is well documented and has a detailed API reference.
+- **Well Documented**: The library is well documented and has a detailed API reference and usage examples.
 
 ## Installation
 
@@ -794,7 +794,176 @@ The `verify` function is promise-based asynchronous version of `verifySync`.
 
 - **Returns**: In case of successful verification, the decoded payload is returned. Otherwise, an error is thrown.
 
-## Errors
+## Errors Codes
+
+The library may throw the following errors:
+
+### `RsaPrivateKeyInvalid`
+
+Thrown when the provided RSA/RSA-PSS private key is invalid.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'RsaPrivateKeyInvalid'
+- `message`: 'Invalid RSA private key: The provided private key is not supported.'
+
+### `EcdsaPrivateKeyInvalid`
+
+Thrown when the provided ECDSA private key is invalid.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'EcdsaPrivateKeyInvalid'
+- `message`: 'Invalid ECDSA private key: The provided private key is not supported.'
+
+### `JwtTokenHeaderInvalid`
+
+Thrown when the JWT token header is invalid.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'JwtTokenHeaderInvalid'
+- `message`: 'Invalid JWT token header: The header is not a valid JSON object encoded in base64url format.'
+
+### `JwtTokenPayloadInvalid`
+
+Thrown when the JWT token payload is invalid.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'JwtTokenPayloadInvalid'
+- `message`: 'Invalid JWT token payload: The payload is not a valid JSON object encoded in base64url format.'
+
+### `JwtTokenSignatureInvalid`
+
+Thrown when the JWT token signature is invalid.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'JwtTokenSignatureInvalid'
+- `message`: 'Invalid JWT token signature: The signature is not a valid base64url string.'
+
+### `JwtTokenMalformed`
+
+Thrown when the JWT token string is malformed.
+
+**Error Type**: `SjwtTypeError`
+
+**Error Object**:
+
+- `name`: 'JwtTokenMalformed'
+- `message`: 'Invalid JWT token: The token is not a valid JSON Web Token.'
+
+### `SjwtValidationError`
+
+Thrown when any of the API arguments does not meet the validation criteria.
+
+**Error Type**: `SjwtValidationError`
+
+**Error Object**:
+
+- `name`: 'SjwtValidationError'
+- `message`: '<_Error message describing the validation error_>'
+
+### `InvalidTokenType`
+
+Thrown during token verification when the token type is not `JWT`.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidTokenType'
+- `message`: 'Token type is not JWT'
+
+### `InvalidAlgorithm`
+
+Thrown during token verification when the algorithm in the token header is not in the list of allowed algorithms.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidAlgorithm'
+- `message`: 'Algorithm `header.alg` is not included in the list of allowed "algorithms" `options.algorithms`'
+
+### `InvalidIssuer`
+
+Thrown during token verification when the issuer in the token payload is not in the list of allowed issuers.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidIssuer'
+- `message`: 'jwt issuer invalid. expected: <`options.issuer`>'
+
+### `InvalidSubject`
+
+Thrown during token verification when the subject in the token payload is not the specified allowed subjects.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidSubject'
+- `message`: 'jwt subject invalid. expected: <`options.subject`>'
+
+### `InvalidAudience`
+
+Thrown during token verification when the audience in the token payload is not in the list of allowed audiences.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidAudience'
+- `message`: 'jwt audience invalid'
+
+### `InvalidJwtId`
+
+Thrown during token verification when the JWT ID in the token payload is not the specified allowed JWT ID.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidJwtId'
+- `message`: 'jwt jwtId invalid. expected: <`options.jwtId`>'
+
+### `SjwtExpiredTokenError`
+
+Thrown during token verification when the token is expired.
+
+**Error Type**: `SjwtExpiredTokenError`
+
+**Error Object**:
+
+- `name`: 'SjwtExpiredTokenError'
+- `message`:
+  - 'Expired token: jwt expired': If `options.ignoreExpiration` is `false` and the token is expired.
+  - 'Expired token: jwt maxAge exceeded': If `options.maxAge` is specified and the token age exceeds the maximum allowed age.
+
+### `InvalidSignature`
+
+Thrown during token verification when the signature is invalid.
+
+**Error Type**: `SjwtVerificationError`
+
+**Error Object**:
+
+- `name`: 'InvalidSignature'
+- `message`: 'signature verification failed'
 
 ## Supported Algorithms
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,26 +18,26 @@ export const ALGORITHMS: Algorithm[] = [
   ...ASYMMETRIC_KEY_ALGORITHMS,
 ];
 
-export const RSA_PRIVATE_KEY_INVALID: string = 'RSA_PRIVATE_KEY_INVALID';
+export const RSA_PRIVATE_KEY_INVALID: string = 'RsaPrivateKeyInvalid';
 export const RSA_PRIVATE_KEY_INVALID_ERROR_MSG: string =
   'Invalid RSA private key: The provided private key is not supported.';
-export const ECDSA_PRIVATE_KEY_INVALID: string = 'ECDSA_PRIVATE_KEY_INVALID';
+export const ECDSA_PRIVATE_KEY_INVALID: string = 'EcdsaPrivateKeyInvalid';
 export const ECDSA_PRIVATE_KEY_INVALID_ERROR_MSG: string =
   'Invalid ECDSA private key: The provided private key is not supported.';
 
-export const JWT_TOKEN_HEADER_INVALID = 'JWT_TOKEN_HEADER_INVALID';
+export const JWT_TOKEN_HEADER_INVALID = 'JwtTokenHeaderInvalid';
 export const JWT_TOKEN_HEADER_INVALID_ERROR_MSG =
   'Invalid JWT token header: The header is not a valid JSON object encoded in base64url format.';
 
-export const JWT_TOKEN_PAYLOAD_INVALID = 'JWT_TOKEN_PAYLOAD_INVALID';
+export const JWT_TOKEN_PAYLOAD_INVALID = 'JwtTokenPayloadInvalid';
 export const JWT_TOKEN_PAYLOAD_INVALID_ERROR_MSG =
   'Invalid JWT token payload: The payload is not a valid JSON object encoded in base64url format.';
 
-export const JWT_SIGNATURE_INVALID = 'JWT_SIGNATURE_INVALID';
+export const JWT_SIGNATURE_INVALID = 'JwtSignatureInvalid';
 export const JWT_SIGNATURE_INVALID_ERROR_MSG =
   'Invalid JWT signature: The signature is not a valid base64url string.';
 
-export const JWT_TOKEN_MALFORMED = 'JWT_TOKEN_MALFORMED';
+export const JWT_TOKEN_MALFORMED = 'JwtTokenMalformed';
 export const JWT_TOKEN_MALFORMED_ERROR_MSG =
   'Invalid JWT token: The token is not a valid JSON Web Token.';
 

--- a/src/helpers/verify_payload_helpers.ts
+++ b/src/helpers/verify_payload_helpers.ts
@@ -1,8 +1,10 @@
 import ms from 'ms';
 import { Payload, VerifyOptions } from '../types/index.js';
 import {
+  createSjwtTypeError,
   createSjwtVerificationError,
   createSjwtExpiredTokenError,
+  createSjwtValidationError,
 } from '../utils/error/index.js';
 
 export function verifyExpiration(
@@ -14,10 +16,7 @@ export function verifyExpiration(
 
   if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
     if (typeof payload.exp !== 'number') {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.exp property must be a number.',
-      );
+      throw createSjwtTypeError('number', typeof payload.exp);
     }
 
     if (clockTimestamp >= payload.exp + (options.clockTolerance || 0)) {
@@ -30,17 +29,13 @@ export function verifyExpiration(
 
   if (options.maxAge) {
     if (typeof payload.iat === 'undefined') {
-      throw createSjwtVerificationError(
-        'IatMissing',
+      throw createSjwtValidationError(
         'iat required when maxAge is specified',
       );
     }
 
     if (typeof payload.iat !== 'number') {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.iat property must be a number.',
-      );
+      throw createSjwtTypeError('number', typeof payload.iat);
     }
 
     let maxAgeTimestamp: number;
@@ -50,8 +45,7 @@ export function verifyExpiration(
       try {
         maxAgeTimestamp = payload.iat + ms(options.maxAge) / 1000;
       } catch (_) {
-        throw createSjwtVerificationError(
-          'InvalidMaxAgeOption',
+        throw createSjwtValidationError(
           'The maxAge option must be a number of seconds or string representing a timespan eg: "1d", "20h", 60',
         );
       }
@@ -69,17 +63,13 @@ export function verifyExpiration(
 export function verifyIssuer(payload: Payload, options: VerifyOptions): void {
   if (options.issuer) {
     if (typeof payload.iss === 'undefined') {
-      throw createSjwtVerificationError(
-        'IssMissing',
+      throw createSjwtValidationError(
         'jwt issuer missing from payload',
       );
     }
 
     if (typeof payload.iss !== 'string') {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.iss property must be a string.',
-      );
+      throw createSjwtTypeError('string', typeof payload.iss);
     }
 
     if (typeof options.issuer === 'string') {
@@ -101,17 +91,13 @@ export function verifyIssuer(payload: Payload, options: VerifyOptions): void {
 export function verifySubject(payload: Payload, options: VerifyOptions): void {
   if (options.subject) {
     if (typeof payload.sub === 'undefined') {
-      throw createSjwtVerificationError(
-        'SubMissing',
+      throw createSjwtValidationError(
         'jwt subject missing from payload',
       );
     }
 
     if (typeof payload.sub !== 'string') {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.sub property must be a string.',
-      );
+      throw createSjwtTypeError('string', typeof payload.sub);
     }
 
     if (payload.sub !== options.subject) {
@@ -126,17 +112,13 @@ export function verifySubject(payload: Payload, options: VerifyOptions): void {
 export function verifyAudience(payload: Payload, options: VerifyOptions): void {
   if (options.audience) {
     if (typeof payload.aud === 'undefined') {
-      throw createSjwtVerificationError(
-        'AudMissing',
+      throw createSjwtValidationError(
         'jwt audience missing from payload',
       );
     }
 
     if (typeof payload.aud !== 'string' && !Array.isArray(payload.aud)) {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.aud property must be a string or an array of strings.',
-      );
+      throw createSjwtTypeError('string or array of strings', typeof payload.aud);
     }
 
     const audiences = Array.isArray(options.audience)
@@ -173,17 +155,13 @@ export function verifyAudience(payload: Payload, options: VerifyOptions): void {
 export function verifyJwtId(payload: Payload, options: VerifyOptions): void {
   if (options.jwtId) {
     if (typeof payload.jti === 'undefined') {
-      throw createSjwtVerificationError(
-        'JwtIdMissing',
+      throw createSjwtValidationError(
         'jwt jwtId missing from payload',
       );
     }
 
     if (typeof payload.jti !== 'string') {
-      throw createSjwtVerificationError(
-        'InvalidPayload',
-        'The payload.jti property must be a string.',
-      );
+      throw createSjwtTypeError('string', typeof payload.jti);
     }
 
     if (payload.jti !== options.jwtId) {

--- a/tests/verify_payload_audience.test.ts
+++ b/tests/verify_payload_audience.test.ts
@@ -133,7 +133,7 @@ describe('Verify Payload Audience', () => {
     };
 
     expect(() => verifyAudience(payload, options)).toThrow(
-      'The payload.aud property must be a string or an array of strings.',
+      'Expected type to be string or array of strings, got number',
     );
   });
 

--- a/tests/verify_payload_expiration.test.ts
+++ b/tests/verify_payload_expiration.test.ts
@@ -38,7 +38,7 @@ describe('verify Payload Expiration', () => {
       secretKey: 'secret',
     };
     expect(() => verifyExpiration(payload, options)).toThrow(
-      'The payload.exp property must be a number.',
+      'Expected type to be number, got string',
     );
   });
 
@@ -85,7 +85,7 @@ describe('verify Payload Expiration', () => {
       maxAge: 10,
     };
     expect(() => verifyExpiration(payload, options)).toThrow(
-      'The payload.iat property must be a number.',
+      'Expected type to be number, got string',
     );
   });
 

--- a/tests/verify_payload_issuer.test.ts
+++ b/tests/verify_payload_issuer.test.ts
@@ -51,7 +51,7 @@ describe('Verify Payload Issuer', () => {
     };
 
     expect(() => verifyIssuer(payload, options)).toThrow(
-      'The payload.iss property must be a string.',
+      'Expected type to be string, got number',
     );
   });
 

--- a/tests/verify_payload_jwtid.test.ts
+++ b/tests/verify_payload_jwtid.test.ts
@@ -29,7 +29,7 @@ describe('Verify Payload JWT ID', () => {
     };
 
     expect(() => verifyJwtId(payload, options)).toThrow(
-      'The payload.jti property must be a string.',
+      'Expected type to be string, got number',
     );
   });
 

--- a/tests/verify_payload_subject.test.ts
+++ b/tests/verify_payload_subject.test.ts
@@ -29,7 +29,7 @@ describe('Verify Payload Subject', () => {
     };
 
     expect(() => verifySubject(payload, options)).toThrow(
-      'The payload.sub property must be a string.',
+      'Expected type to be string, got number',
     );
   });
 


### PR DESCRIPTION
This pull request adds the Errors Codes section to the docs.

During writing the docs I found some issues:

- Some error names didn't follow the convention, that it should be in **PascalCase**.
- I was using the wrong Error types in some places, which required to fix it in both source code and test suites.